### PR TITLE
Add VirtualEnv and Chruby segment in leftmost position of the left prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -95,5 +95,14 @@ function fish_prompt
         segment white 333 " %% "
     end
 
+    if set -q VIRTUAL_ENV
+        segment yellow blue " "(basename "$VIRTUAL_ENV")" "
+    end
+
+    if set -q RUBY_VERSION
+        segment red fff " "(basename "$RUBY_VERSION")" "
+    end
+
+
     segment_close
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -103,6 +103,5 @@ function fish_prompt
         segment red fff " "(basename "$RUBY_VERSION")" "
     end
 
-
     segment_close
 end


### PR DESCRIPTION
Builds on #3 but puts the Python/Ruby version in the leftmost segment of the left prompt, much like [bobthefish](https://github.com/oh-my-fish/theme-bobthefish).
