### PR TITLE
Configurable: disable ruby and virtualenv name in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ With [fisherman]
 fisher metro
 ```
 
+### Configure
+
+You can add the following lines to your `fish` configuration to change how `metro` works:
+
+```fish
+set -g theme_display_ruby no        # Disables displaying the current ruby version
+set -g theme_display_virtualenv no  # Disables displaying the current virtualenv name
+```
+
 ## Features
 
 * Git

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -95,11 +95,11 @@ function fish_prompt
         segment white 333 " %% "
     end
 
-    if set -q VIRTUAL_ENV
+    if [ "$theme_display_virtualenv" != 'no' ]; and set -q VIRTUAL_ENV
         segment yellow blue " "(basename "$VIRTUAL_ENV")" "
     end
 
-    if set -q RUBY_VERSION
+    if [ "$theme_display_ruby" != 'no' ]; and set -q RUBY_VERSION
         segment red fff " "(basename "$RUBY_VERSION")" "
     end
 


### PR DESCRIPTION
Similarly to how `bobthefish` does it.
