### PR TITLE
Support vi mode in the powerline

### DIFF
--- a/fish_mode_prompt.fish
+++ b/fish_mode_prompt.fish
@@ -1,0 +1,2 @@
+function fish_mode_prompt
+end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -5,19 +5,6 @@ function fish_prompt
     set -l base
     set -l base_color 888 161616
 
-    if test "$fish_key_bindings" = "fish_vi_key_bindings"
-      switch $fish_bind_mode
-        case default
-          segment brwhite red "[N]"
-        case insert
-          segment brwhite green "[I]"
-        case replace-one
-          segment brwhite green "[R]"
-        case visual
-          segment brwhite magenta "[V]"
-      end
-    end
-
     if test "$PWD" = ~
         set base "~"
 
@@ -114,6 +101,19 @@ function fish_prompt
 
     if set -q RUBY_VERSION
         segment red fff " "(basename "$RUBY_VERSION")" "
+    end
+
+    if test "$fish_key_bindings" = "fish_vi_key_bindings"
+      switch $fish_bind_mode
+        case default
+          segment brwhite red "[N]"
+        case insert
+          segment brwhite green "[I]"
+        case replace-one
+          segment brwhite green "[R]"
+        case visual
+          segment brwhite magenta "[V]"
+      end
     end
 
     segment_close

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -5,6 +5,19 @@ function fish_prompt
     set -l base
     set -l base_color 888 161616
 
+    if test "$fish_key_bindings" = "fish_vi_key_bindings"
+      switch $fish_bind_mode
+        case default
+          segment brwhite red "[N]"
+        case insert
+          segment brwhite green "[I]"
+        case replace-one
+          segment brwhite green "[R]"
+        case visual
+          segment brwhite magenta "[V]"
+      end
+    end
+
     if test "$PWD" = ~
         set base "~"
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -108,9 +108,9 @@ function fish_prompt
         case default
           segment white red "[N]"
         case insert
-          segment white green "[I]"
+          segment black green "[I]"
         case replace-one
-          segment white blue "[R]"
+          segment yellow blue "[R]"
         case visual
           segment white magenta "[V]"
       end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -106,13 +106,13 @@ function fish_prompt
     if test "$fish_key_bindings" = "fish_vi_key_bindings"
       switch $fish_bind_mode
         case default
-          segment brwhite red "[N]"
+          segment white red "[N]"
         case insert
-          segment brwhite green "[I]"
+          segment white green "[I]"
         case replace-one
-          segment brwhite green "[R]"
+          segment white blue "[R]"
         case visual
-          segment brwhite magenta "[V]"
+          segment white magenta "[V]"
       end
     end
 


### PR DESCRIPTION
`fish_mode_prompt.fish` is necessary because it's the only way to properly disable how fish shell hardcodes in the position of the vi mode prompt.